### PR TITLE
Remove toolchain from HEADER_SEARCH_PATHS

### DIFF
--- a/RNBuglife.xcodeproj/project.pbxproj
+++ b/RNBuglife.xcodeproj/project.pbxproj
@@ -220,7 +220,6 @@
 				);
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
-					"/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/**",
 					"$(SRCROOT)/../../React/**",
 					"$(SRCROOT)/../../node_modules/react-native/React/**",
 				);
@@ -239,7 +238,6 @@
 				);
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
-					"/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/**",
 					"$(SRCROOT)/../../React/**",
 					"$(SRCROOT)/../../node_modules/react-native/React/**",
 				);


### PR DESCRIPTION
After upgrading to Xcode 9.0, this module broke our build. It seems like any references to the default toolchain in `HEADER_SEARCH_PATHS` now cause cyclic dependency errors.

For example, see: https://stackoverflow.com/questions/46271892/xcode-9-module-cyclic-dependencies-darwin-std-darwin

Removing these two lines fixed the issue for us (and Buglife continues to work).