### PR TITLE
Fixes and improvements to the attachment addition method

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,13 @@ var myData = { }; // This should be a JSON object with your data
 Buglife.addAttachmentWithJSON(myData, "MyData.json");
 ```
 
+It’s also possible to add a String attachment:
+
+```javascript
+var myText = "great detailed log"; // This should be a String object with your data
+Buglife.addAttachmentWithString(myText, "MyText.text");
+```
+
 In some cases, you may wish to add an attachment on every invocation of the bug reporter; You can do so by subscribing to the `BuglifeAttachmentRequest` event:
 
 ```javascript

--- a/android/src/main/java/com/buglife/BuglifeModule.java
+++ b/android/src/main/java/com/buglife/BuglifeModule.java
@@ -4,13 +4,13 @@ package com.buglife;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
-import com.facebook.react.bridge.Callback;
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.ReactPackage;
 
 import com.buglife.sdk.Buglife;
 import com.buglife.sdk.InvocationMethod;
 import com.buglife.sdk.Attachment;
+import com.facebook.react.bridge.ReadableMap;
 
 import org.json.JSONObject;
 
@@ -80,9 +80,25 @@ public class BuglifeModule extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
-  public void addAttachmentWithJSON(JSONObject data, String attachmentFileName, Promise promise) {
+  public void addAttachmentWithJSON(ReadableMap jsonData, String attachmentFileName, Promise promise) {
     try {
-      Attachment attachment = new Attachment.Builder(attachmentFileName, Attachment.TYPE_JSON).build(data);
+      JSONObject jsonObject = (JSONObject)jsonData;
+      Attachment attachment = new Attachment.Builder(attachmentFileName, Attachment.TYPE_JSON).build(jsonObject);
+
+      Buglife.addAttachment(attachment); // The android version of the API does not return a boolean
+      promise.resolve(null);
+    }
+    catch (Exception e) {
+      e.printStackTrace();
+      promise.reject("ATTACHMENT_ERR", e);
+    }
+  }
+
+  @ReactMethod
+  public void addAttachmentWithString(String textData, String attachmentFileName, Promise promise) {
+    try {
+      Attachment attachment = new Attachment.Builder(attachmentFileName, Attachment.TYPE_TEXT).build(textData);
+
       Buglife.addAttachment(attachment); // The android version of the API does not return a boolean
       promise.resolve(null);
     }

--- a/ios/RNBuglife.m
+++ b/ios/RNBuglife.m
@@ -73,10 +73,10 @@ RCT_EXPORT_METHOD(addAttachmentWithContents:(NSString *)base64Contents type:(NSS
     [self _addAttachmentWithData:data type:type filename:filename resolver:resolve rejecter:reject];
 }
 
-RCT_EXPORT_METHOD(addAttachmentWithJSON:(id)jsonObject filename:(NSString *)filename resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
+RCT_EXPORT_METHOD(addAttachmentWithJSON:(id)json filename:(NSString *)filename resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
 {
     NSError *error = nil;
-    NSData *data = [NSJSONSerialization dataWithJSONObject:jsonObject options:0 error:&error];
+    NSData *data = [NSJSONSerialization dataWithJSONObject:json options:0 error:&error];
     
     if (!data) {
         reject(error.domain, error.localizedDescription, error);
@@ -84,6 +84,13 @@ RCT_EXPORT_METHOD(addAttachmentWithJSON:(id)jsonObject filename:(NSString *)file
     }
     
     [self _addAttachmentWithData:data type:LIFEAttachmentTypeIdentifierJSON filename:filename resolver:resolve rejecter:reject];
+}
+
+RCT_EXPORT_METHOD(addAttachmentWithString:(NSString *)text filename:(NSString *)filename resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
+{
+    NSData *data = data = [(NSString *)text dataUsingEncoding:NSUTF8StringEncoding];
+    
+    [self _addAttachmentWithData:data type:LIFEAttachmentTypeIdentifierText filename:filename resolver:resolve rejecter:reject];
 }
 
 - (void)_addAttachmentWithData:(NSData *)data type:(NSString *)type filename:(NSString *)filename resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject


### PR DESCRIPTION
- Android: added also support to send send a string attachment, as in iOS

- Android: fixed attachment method, which did not work (`JSONObject` as param causes app to crash; switched to RN’s ReadableMap)

- iOS & Android: separated the String attachment method to a new one: `addAttachmentWithString` (as there a technical problem to support both on the same method on Android)